### PR TITLE
Work with DECAF Instance Profiles

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Main where
 
 import           Data.Aeson                  (Value, (.:))
@@ -16,88 +12,35 @@ import           Data.Version                (showVersion)
 import qualified Decaf.Client                as DC
 import           Decaf.Client.Internal.Utils (applyFirst)
 import           GHC.Generics                (Generic)
+import           MicrolotBatchRunner         (MicrolotBatchRunConfig(MicrolotBatchRunConfig), runBatchMicrolot)
 import qualified Options.Applicative         as OA
 import           Paths_decaf_client          (version)
 import           System.Exit                 (ExitCode, die, exitFailure, exitSuccess, exitWith)
 import           System.IO                   (hPutStrLn, stderr)
 
 
+-- | Entrypoint of the CLI program.
 main :: IO ()
 main = exitWith =<< (cliProgram =<< OA.execParser cliProgramParserInfo)
 
 
-data MicrolotCommandParameters = MicrolotCommandParameters
-  { microlotCommandParametersConfigFile      :: !FilePath
-  , microlotCommandParametersProfile         :: !T.Text
-  , microlotCommandParametersQuery           :: !FilePath
-  , microlotCommandParametersQueryParameters :: !(Maybe Value)
-  }
+-- | CLI program.
+cliProgram :: Command -> IO ExitCode
+cliProgram (CommandMicrolot config) = runBatchMicrolot config >> exitSuccess
+cliProgram (CommandVersions fp)     = hPutStrLn stderr "Not implemented yet." >> exitFailure
 
 
-microlotCommandParametersParser :: OA.Parser MicrolotCommandParameters
-microlotCommandParametersParser = MicrolotCommandParameters
-  <$> OA.strOption (OA.long "config" <> OA.metavar "CONFIG" <> OA.help "Path to generic DECAF configuration file")
-  <*> OA.strOption (OA.long "profile" <> OA.metavar "PROFILE" <> OA.help "Profile name")
-  <*> OA.strOption (OA.long "query" <> OA.metavar "QUERY" <> OA.help "Microlot GraphQL query")
-  <*> OA.optional (queryParametersOption (OA.long "params" <> OA.metavar "PARAM" <> OA.help "Microlot GraphQL query parameters"))
-
-
-queryParametersOption :: OA.Mod OA.OptionFields Value -> OA.Parser Value
-queryParametersOption = OA.option optionQueryParameters
-
-
-optionQueryParameters :: OA.ReadM Value
-optionQueryParameters = OA.eitherReader (\x -> maybe (Left ("Invalid JSON for query parameters: \"" <> x <> "\"")) Right (Aeson.decode (BLC.pack x)))
-
-
-microlotCommandProgram :: MicrolotCommandParameters -> IO ExitCode
-microlotCommandProgram (MicrolotCommandParameters fileConfig profileName fileQuery params) = do --Program.runAndUploadDir config dir >> exitSuccess
-  eConfig <- Aeson.eitherDecodeFileStrict fileConfig
-  case eConfig of
-    Left x -> hPutStrLn stderr ("Can not read the configuration file: " <> x) >> exitFailure
-    Right c -> case HM.lookup profileName (decafConfigProfiles c) of
-      Nothing -> hPutStrLn stderr ("Can not find the profile: " <> T.unpack profileName) >> exitFailure
-      Just (DecafConfigProfile _ u k s) -> case DC.mkDecafClient u (DC.CredentialsKey (DC.KeyCredentials k s)) of
-        Left err -> hPutStrLn stderr ("Can not create the DECAF client: " <> show err) >> exitFailure
-        Right dc -> do
-          query <- readFile fileQuery
-          value <- DC.microlotResponseData . DC.responseValue <$> DC.runMicrolot (maybe (DC.mkMicrolotQuery' query) (DC.mkMicrolotQuery query) params) (DC.decafClientMicrolot dc)
-          BLC.putStr (Aeson.encode (value :: Aeson.Value)) >> exitSuccess
-
-
-data DecafConfigProfile = DecafConfigProfile
-  { decafConfigProfileName   :: !T.Text
-  , decafConfigProfileUrl    :: !T.Text
-  , decafConfigProfileKey    :: !T.Text
-  , decafConfigProfileSecret :: !T.Text
-  } deriving (Generic)
-
-instance Aeson.FromJSON DecafConfigProfile where
-  parseJSON = Aeson.genericParseJSON Aeson.defaultOptions { Aeson.fieldLabelModifier = applyFirst toLower . drop 18 }
-
-
-newtype DecafConfig = DecafConfig { decafConfigProfiles :: HM.HashMap T.Text DecafConfigProfile }
-
-instance Aeson.FromJSON DecafConfig where
-  parseJSON (Aeson.Object x) = (\x -> DecafConfig $ HM.fromList (zip (fmap decafConfigProfileName x) x)) <$> (.:) x "profiles"
-  parseJSON x                = fail $ "Unexpected type for DECAF configuration file contents: " <> show x
-
-
--- | Registry of commands.
+-- | Commands registry
 data Command =
-    CommandBarista
-  | CommandMicrolot MicrolotCommandParameters
-
-
--- | Parsed command line arguments.
-newtype CliArguments = CliArguments { cliArgumentsCommand :: Command }
+    CommandMicrolot MicrolotBatchRunConfig
+  | CommandVersions FilePath
 
 
 -- | CLI arguments parser.
-parserProgramOptions :: OA.Parser CliArguments
-parserProgramOptions = CliArguments <$> OA.hsubparser
-  (  OA.command "barista" (OA.info (pure CommandBarista) (OA.progDesc "Run Barista"))
-  <> OA.command "microlot" (OA.info (CommandMicrolot <$> microlotCommandParametersParser) (OA.progDesc "Run Barista"))
+parserProgramOptions :: OA.Parser Command
+parserProgramOptions = OA.hsubparser
+  (  OA.command "microlot" (OA.info (CommandMicrolot <$> microlotRunConfigParser) (OA.progDesc "Run DECAF Microlot query over profiles"))
+  <> OA.command "versions" (OA.info (CommandVersions <$> profileFilePathParser) (OA.progDesc "Get DECAF Barista versions for all profiles"))
   )
 
 
@@ -107,13 +50,37 @@ parserVersionOption = OA.infoOption (showVersion version) (OA.long "version" <> 
 
 
 -- | CLI program information.
-cliProgramParserInfo :: OA.ParserInfo CliArguments
+cliProgramParserInfo :: OA.ParserInfo Command
 cliProgramParserInfo = OA.info
   (OA.helper <*> parserVersionOption <*> parserProgramOptions)
   (OA.fullDesc <> OA.progDesc "DECAF Client" <> OA.header "decafcli - DECAF Command-line Client Application")
 
 
--- | CLI program.
-cliProgram :: CliArguments -> IO ExitCode
-cliProgram (CliArguments CommandBarista)           = hPutStrLn stderr "Not implemented yet." >> exitFailure
-cliProgram (CliArguments (CommandMicrolot params)) = microlotCommandProgram params
+-- * Helpers
+-- $helpers
+
+
+microlotRunConfigParser :: OA.Parser MicrolotBatchRunConfig
+microlotRunConfigParser = MicrolotBatchRunConfig
+  <$> profileFilePathParser
+  <*> OA.optional profileNameParser
+  <*> OA.strOption (OA.long "query" <> OA.metavar "QUERY" <> OA.help "Microlot GraphQL query")
+  <*> OA.optional (queryParametersOption (OA.long "params" <> OA.metavar "PARAM" <> OA.help "Microlot GraphQL query parameters"))
+
+
+profileFilePathParser :: OA.Parser FilePath
+profileFilePathParser =
+  OA.strOption (OA.long "file-profiles" <> OA.metavar "FILE-PROFILES" <> OA.help "Path to profiles path")
+
+
+profileNameParser :: OA.Parser T.Text
+profileNameParser =
+  OA.strOption (OA.long "profile" <> OA.metavar "PROFILE-NAME" <> OA.help "Name of the profile")
+
+
+queryParametersOption :: OA.Mod OA.OptionFields Value -> OA.Parser Value
+queryParametersOption = OA.option optionQueryParameters
+
+
+optionQueryParameters :: OA.ReadM Value
+optionQueryParameters = OA.eitherReader (\x -> maybe (Left ("Invalid JSON for query parameters: \"" <> x <> "\"")) Right (Aeson.decode (BLC.pack x)))

--- a/app/MicrolotBatchRunner.hs
+++ b/app/MicrolotBatchRunner.hs
@@ -1,0 +1,103 @@
+-- | This module provides the runner for batch DECAF Microlot query for
+-- requested profiles.
+
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module MicrolotBatchRunner where
+
+import           Control.Exception      (IOException, SomeException)
+import           Control.Monad.Catch    (MonadCatch(catch), MonadThrow)
+import           Control.Monad.IO.Class (MonadIO(..))
+import qualified Control.Monad.Parallel as MP
+import           Data.Aeson             ((.=))
+import qualified Data.Aeson             as Aeson
+import qualified Data.ByteString        as B
+import qualified Data.ByteString.Char8  as BC
+import qualified Data.ByteString.Lazy   as BL
+import qualified Data.Text              as T
+import qualified Data.Vector            as V
+import           Decaf.Client
+                 ( DecafClient(decafClientMicrolot)
+                 , MicrolotQuery
+                 , MicrolotResponse(microlotResponseData)
+                 , Profile(profileName, profileRemote)
+                 , Response(responseValue)
+                 , mkClientFromProfile
+                 , mkMicrolotQuery
+                 , mkMicrolotQuery'
+                 , readProfiles
+                 , runMicrolot
+                 , throwIOException
+                 )
+import           GHC.Stack              (HasCallStack)
+
+
+-- | Data definition for DECAF Microlot batch run configuration.
+data MicrolotBatchRunConfig = MicrolotBatchRunConfig
+  { microlotBatchRunConfigFile        :: !FilePath
+  , microlotBatchRunConfigProfileName :: !(Maybe T.Text)
+  , microlotBatchRunConfigQuery       :: !FilePath
+  , microlotBatchRunConfigQueryParams :: !(Maybe Aeson.Value)
+  }
+
+
+-- | Attempts to run the config.
+runBatchMicrolot
+  :: HasCallStack
+  => MP.MonadParallel m
+  => MonadCatch m
+  => MonadThrow m
+  => MonadIO m
+  => MicrolotBatchRunConfig
+  -> m ()
+runBatchMicrolot MicrolotBatchRunConfig{..} = do
+  allProfiles <- readProfiles microlotBatchRunConfigFile
+  let profiles = case microlotBatchRunConfigProfileName of
+        Nothing -> allProfiles
+        Just sn -> filter (\x -> profileName x == sn) allProfiles
+  results <- MP.mapM (runQueryForProfile microlotBatchRunConfigQuery microlotBatchRunConfigQueryParams) profiles
+  let zipped = Aeson.Array . V.fromList
+          $ (\(x, y) -> Aeson.object ["name" .= profileName x, "remote" .= profileRemote x, "result" .= y])
+        <$> zip profiles results
+  liftIO . BL.putStr $ Aeson.encode zipped
+
+
+-- | Attempts to run the query for the profile.
+runQueryForProfile
+  :: HasCallStack
+  => MonadCatch m
+  => MonadThrow m
+  => MonadIO m
+  => FilePath
+  -> Maybe Aeson.Value
+  -> Profile
+  -> m Aeson.Value
+runQueryForProfile fp vars profile = do
+  query <- buildMicrolotQuery fp vars
+  let client = mkClientFromProfile profile
+  attempt query client `catch` handle
+  where
+    attempt q c = microlotResponseData . responseValue <$> runMicrolot q (decafClientMicrolot c)
+    handle = \(x :: SomeException) -> pure (Aeson.String (T.pack . show $ x))
+
+
+-- | Attempts to build a 'MicrolotQuery' from the given GQL file path and
+-- optional query variables.
+buildMicrolotQuery
+  :: HasCallStack
+  => MonadCatch m
+  => MonadThrow m
+  => MonadIO m
+  => FilePath
+  -> Maybe Aeson.Value
+  -> m (MicrolotQuery Aeson.Value)
+buildMicrolotQuery fp mVars = do
+  gql <- BC.unpack <$> liftIO (B.readFile fp `catch` transformIOException)
+  case mVars of
+    Nothing -> pure $ mkMicrolotQuery' gql
+    Just sv -> pure $ mkMicrolotQuery gql sv
+  where
+    transformIOException :: MonadThrow m => IOException -> m a
+    transformIOException exc = throwIOException (T.pack $ "Cannot read GraphQL query file: " <> fp) exc

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -84,7 +84,7 @@ library
       TypeOperators
       TypeSynonymInstances
       OverloadedStrings
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall -Wunused-packages
   build-depends:
       aeson
     , base >=4.7 && <5
@@ -94,11 +94,9 @@ library
     , deriving-aeson
     , exceptions
     , http-conduit
-    , http-types
     , mtl
     , network-uri
     , text
-    , unordered-containers
     , yaml
   default-language: Haskell2010
 
@@ -120,7 +118,6 @@ executable decafcli
     , deriving-aeson
     , exceptions
     , http-conduit
-    , http-types
     , monad-parallel
     , mtl
     , network-uri
@@ -150,11 +147,9 @@ test-suite decaf-client-doctest
     , doctest
     , exceptions
     , http-conduit
-    , http-types
     , mtl
     , network-uri
     , text
-    , unordered-containers
     , yaml
   default-language: Haskell2010
 
@@ -176,10 +171,8 @@ test-suite decaf-client-test
     , deriving-aeson
     , exceptions
     , http-conduit
-    , http-types
     , mtl
     , network-uri
     , text
-    , unordered-containers
     , yaml
   default-language: Haskell2010

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -102,31 +102,6 @@ library
     , yaml
   default-language: Haskell2010
 
-executable decaf-client-examples-accountinfo-exe
-  main-is: Main.hs
-  other-modules:
-      Paths_decaf_client
-  hs-source-dirs:
-      examples/accountinfo
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      aeson
-    , base >=4.7 && <5
-    , base64-bytestring
-    , bytestring
-    , case-insensitive
-    , decaf-client
-    , deriving-aeson
-    , exceptions
-    , http-conduit
-    , http-types
-    , mtl
-    , network-uri
-    , text
-    , unordered-containers
-    , yaml
-  default-language: Haskell2010
-
 executable decafcli
   main-is: Main.hs
   other-modules:

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -105,6 +105,7 @@ library
 executable decafcli
   main-is: Main.hs
   other-modules:
+      MicrolotBatchRunner
       Paths_decaf_client
   hs-source-dirs:
       app
@@ -120,11 +121,13 @@ executable decafcli
     , exceptions
     , http-conduit
     , http-types
+    , monad-parallel
     , mtl
     , network-uri
     , optparse-applicative
     , text
     , unordered-containers
+    , vector
     , yaml
   default-language: Haskell2010
 

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 90f836bda379684c199708d787f74e3d2e29bf5ada683fe6f9fdd0e73ae4a518
 
 name:           decaf-client
 version:        0.0.0.3
@@ -37,6 +35,7 @@ library
       Decaf.Client.Internal.Error
       Decaf.Client.Internal.Exception
       Decaf.Client.Internal.Http
+      Decaf.Client.Internal.Profile
       Decaf.Client.Internal.Remote
       Decaf.Client.Internal.Request
       Decaf.Client.Internal.Response
@@ -99,6 +98,7 @@ library
     , network-uri
     , text
     , unordered-containers
+    , yaml
   default-language: Haskell2010
 
 executable decaf-client-examples-accountinfo-exe
@@ -123,6 +123,7 @@ executable decaf-client-examples-accountinfo-exe
     , network-uri
     , text
     , unordered-containers
+    , yaml
   default-language: Haskell2010
 
 executable decafcli
@@ -148,6 +149,7 @@ executable decafcli
     , optparse-applicative
     , text
     , unordered-containers
+    , yaml
   default-language: Haskell2010
 
 test-suite decaf-client-doctest
@@ -174,6 +176,7 @@ test-suite decaf-client-doctest
     , network-uri
     , text
     , unordered-containers
+    , yaml
   default-language: Haskell2010
 
 test-suite decaf-client-test
@@ -199,4 +202,5 @@ test-suite decaf-client-test
     , network-uri
     , text
     , unordered-containers
+    , yaml
   default-language: Haskell2010

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -33,12 +33,13 @@ library
       Decaf.Client.Internal.Apis.Barista
       Decaf.Client.Internal.Apis.Microlot
       Decaf.Client.Internal.Apis.Pdms
+      Decaf.Client.Internal.Credentials
       Decaf.Client.Internal.Error
+      Decaf.Client.Internal.Exception
       Decaf.Client.Internal.Http
       Decaf.Client.Internal.Remote
       Decaf.Client.Internal.Request
       Decaf.Client.Internal.Response
-      Decaf.Client.Internal.Credentials
       Decaf.Client.Internal.Utils
       Decaf.Client.Version
   other-modules:
@@ -91,6 +92,7 @@ library
     , bytestring
     , case-insensitive
     , deriving-aeson
+    , exceptions
     , http-conduit
     , http-types
     , mtl
@@ -114,6 +116,7 @@ executable decaf-client-examples-accountinfo-exe
     , case-insensitive
     , decaf-client
     , deriving-aeson
+    , exceptions
     , http-conduit
     , http-types
     , mtl
@@ -137,6 +140,7 @@ executable decafcli
     , case-insensitive
     , decaf-client
     , deriving-aeson
+    , exceptions
     , http-conduit
     , http-types
     , mtl
@@ -163,6 +167,7 @@ test-suite decaf-client-doctest
     , decaf-client
     , deriving-aeson
     , doctest
+    , exceptions
     , http-conduit
     , http-types
     , mtl
@@ -187,6 +192,7 @@ test-suite decaf-client-test
     , case-insensitive
     , decaf-client
     , deriving-aeson
+    , exceptions
     , http-conduit
     , http-types
     , mtl

--- a/decaf-client.cabal
+++ b/decaf-client.cabal
@@ -31,6 +31,7 @@ library
       Decaf.Client.Internal.Apis.Barista
       Decaf.Client.Internal.Apis.Microlot
       Decaf.Client.Internal.Apis.Pdms
+      Decaf.Client.Internal.Client
       Decaf.Client.Internal.Credentials
       Decaf.Client.Internal.Error
       Decaf.Client.Internal.Exception

--- a/package.yaml
+++ b/package.yaml
@@ -87,7 +87,9 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - decaf-client
+    - monad-parallel
     - optparse-applicative
+    - vector
 
 tests:
   decaf-client-test:

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - network-uri
 - text
 - unordered-containers
+- yaml
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -24,18 +24,16 @@ dependencies:
 - deriving-aeson
 - exceptions
 - http-conduit
-- http-types
 - mtl
 - network-uri
 - text
-- unordered-containers
 - yaml
 
 library:
   source-dirs: src
   ghc-options:
   - -Wall
-  - -Werror
+  - -Wunused-packages
   default-extensions:
   ## Begin: Haskell 2021 Extensions List
   - BangPatterns
@@ -89,6 +87,7 @@ executables:
     - decaf-client
     - monad-parallel
     - optparse-applicative
+    - unordered-containers
     - vector
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -89,16 +89,6 @@ executables:
     - decaf-client
     - optparse-applicative
 
-  decaf-client-examples-accountinfo-exe:
-    main:                Main.hs
-    source-dirs:         examples/accountinfo
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
-    dependencies:
-    - decaf-client
-
 tests:
   decaf-client-test:
     main:                Main.hs

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ dependencies:
 - bytestring
 - case-insensitive
 - deriving-aeson
+- exceptions
 - http-conduit
 - http-types
 - mtl

--- a/src/Decaf/Client.hs
+++ b/src/Decaf/Client.hs
@@ -52,6 +52,11 @@ module Decaf.Client
 
   , module Decaf.Client.Internal.Credentials
 
+
+    -- * Profiles
+
+  , module Decaf.Client.Internal.Profile
+
     -- * Errors
 
   , module Decaf.Client.Internal.Error
@@ -89,6 +94,7 @@ import Decaf.Client.Internal.Apis.Pdms
 import Decaf.Client.Internal.Credentials
 import Decaf.Client.Internal.Error
 import Decaf.Client.Internal.Exception
+import Decaf.Client.Internal.Profile
 import Decaf.Client.Internal.Remote
 import Decaf.Client.Internal.Request
 import Decaf.Client.Internal.Response

--- a/src/Decaf/Client.hs
+++ b/src/Decaf/Client.hs
@@ -56,6 +56,10 @@ module Decaf.Client
 
   , module Decaf.Client.Internal.Error
 
+    -- * Exceptions
+
+  , module Decaf.Client.Internal.Exception
+
   ) where
 
 
@@ -84,6 +88,7 @@ import Decaf.Client.Internal.Apis.Pdms
        )
 import Decaf.Client.Internal.Credentials
 import Decaf.Client.Internal.Error
+import Decaf.Client.Internal.Exception
 import Decaf.Client.Internal.Remote
 import Decaf.Client.Internal.Request
 import Decaf.Client.Internal.Response

--- a/src/Decaf/Client.hs
+++ b/src/Decaf/Client.hs
@@ -68,8 +68,6 @@ module Decaf.Client
   ) where
 
 
-import Control.Monad.Except                (MonadError)
-import Data.Text                           (Text)
 import Decaf.Client.Internal.Apis.Barista  (BaristaClient, mkBaristaClient, mkBaristaClientM, runBarista, runBaristaBS)
 import Decaf.Client.Internal.Apis.Microlot
        ( MicrolotClient
@@ -91,6 +89,7 @@ import Decaf.Client.Internal.Apis.Pdms
        , mkPdmsQuery'
        , runPdms
        )
+import Decaf.Client.Internal.Client        (DecafClient(..), mkDecafClient)
 import Decaf.Client.Internal.Credentials
 import Decaf.Client.Internal.Error
 import Decaf.Client.Internal.Exception
@@ -98,27 +97,3 @@ import Decaf.Client.Internal.Profile
 import Decaf.Client.Internal.Remote
 import Decaf.Client.Internal.Request
 import Decaf.Client.Internal.Response
-
-
--- | Data definition for a collection of various DECAF API clients.
-data DecafClient = DecafClient
-  { decafClientRemote   :: !Remote          -- ^ DECAF remote definition for the DECAF Instance.
-  , decafClientBarista  :: !BaristaClient   -- ^ DECAF Barista API client.
-  , decafClientMicrolot :: !MicrolotClient  -- ^ DECAF Microlot API client.
-  , decafClientPdms     :: !PdmsClient      -- ^ DECAF PDMS Module API client.
-  }
-
-
--- | Attempts to build a 'DecafClient' with given remote DECAF Instance URL
--- and authentication credentials.
-mkDecafClient
-  :: MonadError DecafClientError m
-  => Text            -- ^ Base URL of remote DECAF Instance
-  -> Credentials     -- ^ Credentials for authenticating requests to remote DECAF Instance
-  -> m DecafClient
-mkDecafClient b c = do
-  r <- parseRemote b
-  let barista = mkBaristaClient r c
-  let microlot = mkMicrolotClient r c
-  let pdms = mkPdmsClient r c
-  pure (DecafClient r barista microlot pdms)

--- a/src/Decaf/Client.hs
+++ b/src/Decaf/Client.hs
@@ -5,6 +5,7 @@ module Decaf.Client
 
     DecafClient(..)
   , mkDecafClient
+  , mkDecafClientE
 
     -- * Barista Client
 
@@ -89,7 +90,7 @@ import Decaf.Client.Internal.Apis.Pdms
        , mkPdmsQuery'
        , runPdms
        )
-import Decaf.Client.Internal.Client        (DecafClient(..), mkDecafClient)
+import Decaf.Client.Internal.Client        (DecafClient(..), mkDecafClient, mkDecafClientE)
 import Decaf.Client.Internal.Credentials
 import Decaf.Client.Internal.Error
 import Decaf.Client.Internal.Exception

--- a/src/Decaf/Client/Internal/Client.hs
+++ b/src/Decaf/Client/Internal/Client.hs
@@ -21,14 +21,29 @@ data DecafClient = DecafClient
   }
 
 
+-- | Builds a 'DecafClient' with given DECAF Instance 'Remote' and
+-- authentication credentials.
+mkDecafClient
+  :: Remote       -- ^ DECAF Instance 'Remote'.
+  -> Credentials  -- ^ Credentials for authenticating requests to remote DECAF Instance
+  -> DecafClient
+mkDecafClient r c =
+  let
+    barista = mkBaristaClient r c
+    microlot = mkMicrolotClient r c
+    pdms = mkPdmsClient r c
+  in
+    DecafClient r barista microlot pdms
+
+
 -- | Attempts to build a 'DecafClient' with given remote DECAF Instance URL
 -- and authentication credentials.
-mkDecafClient
+mkDecafClientE
   :: MonadError DecafClientError m
   => T.Text       -- ^ Base URL of remote DECAF Instance
   -> Credentials  -- ^ Credentials for authenticating requests to remote DECAF Instance
   -> m DecafClient
-mkDecafClient b c = do
+mkDecafClientE b c = do
   r <- parseRemote b
   let barista = mkBaristaClient r c
   let microlot = mkMicrolotClient r c

--- a/src/Decaf/Client/Internal/Client.hs
+++ b/src/Decaf/Client/Internal/Client.hs
@@ -1,0 +1,36 @@
+-- | This module provides 'DecafClient' definition and related helpers.
+
+module Decaf.Client.Internal.Client where
+
+import           Control.Monad.Error.Class           (MonadError)
+import qualified Data.Text                           as T
+import           Decaf.Client.Internal.Apis.Barista  (BaristaClient, mkBaristaClient)
+import           Decaf.Client.Internal.Apis.Microlot (MicrolotClient, mkMicrolotClient)
+import           Decaf.Client.Internal.Apis.Pdms     (PdmsClient, mkPdmsClient)
+import           Decaf.Client.Internal.Credentials   (Credentials)
+import           Decaf.Client.Internal.Error         (DecafClientError)
+import           Decaf.Client.Internal.Remote        (Remote, parseRemote)
+
+
+-- | Data definition for a collection of various DECAF API clients.
+data DecafClient = DecafClient
+  { decafClientRemote   :: !Remote          -- ^ DECAF remote definition for the DECAF Instance.
+  , decafClientBarista  :: !BaristaClient   -- ^ DECAF Barista API client.
+  , decafClientMicrolot :: !MicrolotClient  -- ^ DECAF Microlot API client.
+  , decafClientPdms     :: !PdmsClient      -- ^ DECAF PDMS Module API client.
+  }
+
+
+-- | Attempts to build a 'DecafClient' with given remote DECAF Instance URL
+-- and authentication credentials.
+mkDecafClient
+  :: MonadError DecafClientError m
+  => T.Text       -- ^ Base URL of remote DECAF Instance
+  -> Credentials  -- ^ Credentials for authenticating requests to remote DECAF Instance
+  -> m DecafClient
+mkDecafClient b c = do
+  r <- parseRemote b
+  let barista = mkBaristaClient r c
+  let microlot = mkMicrolotClient r c
+  let pdms = mkPdmsClient r c
+  pure (DecafClient r barista microlot pdms)

--- a/src/Decaf/Client/Internal/Credentials.hs
+++ b/src/Decaf/Client/Internal/Credentials.hs
@@ -68,6 +68,7 @@ data KeyCredentials = KeyCredentials
 -- $internal
 
 
+-- | Data definition for string modifier that lowers the first character.
 data FirstToLower
 
 

--- a/src/Decaf/Client/Internal/Credentials.hs
+++ b/src/Decaf/Client/Internal/Credentials.hs
@@ -5,6 +5,7 @@
 
 module Decaf.Client.Internal.Credentials where
 
+import qualified Data.Char            as C
 import qualified Data.Text            as T
 import qualified Deriving.Aeson       as DA
 import qualified Deriving.Aeson.Stock as DAS
@@ -13,20 +14,20 @@ import qualified Deriving.Aeson.Stock as DAS
 -- | Data definition for available DECAF credentials types.
 --
 -- >>> Data.Aeson.encode (CredentialsHeader "some-header-value")
--- "{\"type\":\"Header\",\"value\":\"some-header-value\"}"
+-- "{\"type\":\"header\",\"value\":\"some-header-value\"}"
 -- >>> Data.Aeson.encode (CredentialsBasic (BasicCredentials "some-username" "some-password"))
--- "{\"type\":\"Basic\",\"value\":{\"username\":\"some-username\",\"password\":\"some-password\"}}"
+-- "{\"type\":\"basic\",\"value\":{\"username\":\"some-username\",\"password\":\"some-password\"}}"
 -- >>> Data.Aeson.encode (CredentialsKey (KeyCredentials "some-api-key" "some-api-secret"))
--- "{\"type\":\"Key\",\"value\":{\"key\":\"some-api-key\",\"secret\":\"some-api-secret\"}}"
+-- "{\"type\":\"key\",\"value\":{\"key\":\"some-api-key\",\"secret\":\"some-api-secret\"}}"
 -- >>> Data.Aeson.encode (CredentialsToken "some-api-token")
--- "{\"type\":\"Token\",\"value\":\"some-api-token\"}"
+-- "{\"type\":\"token\",\"value\":\"some-api-token\"}"
 data Credentials =
     CredentialsHeader !T.Text
   | CredentialsBasic !BasicCredentials
   | CredentialsKey !KeyCredentials
   | CredentialsToken !T.Text
   deriving (Eq, DA.Generic)
-  deriving (DA.FromJSON, DA.ToJSON) via DA.CustomJSON '[DA.ConstructorTagModifier (DA.StripPrefix "Credentials"), DA.SumTaggedObject "type" "value"] Credentials
+  deriving (DA.FromJSON, DA.ToJSON) via DA.CustomJSON '[DA.ConstructorTagModifier '[DA.StripPrefix "Credentials", FirstToLower], DA.SumTaggedObject "type" "value"] Credentials
 
 
 instance Show Credentials where
@@ -61,3 +62,15 @@ data KeyCredentials = KeyCredentials
   }
   deriving (Eq, DA.Generic)
   deriving (DA.FromJSON, DA.ToJSON) via DAS.PrefixedSnake "keyCredentials" KeyCredentials
+
+
+-- * Internal
+-- $internal
+
+
+data FirstToLower
+
+
+instance DA.StringModifier FirstToLower where
+  getStringModifier []       = []
+  getStringModifier (x : xs) = C.toLower x : xs

--- a/src/Decaf/Client/Internal/Error.hs
+++ b/src/Decaf/Client/Internal/Error.hs
@@ -1,8 +1,8 @@
 -- | This module provides DECAF client error data type and related definitions.
 --
 -- Note that currently we are working under 'MonadError'. Eventually, we are
--- going to move onto 'MonadThrow'. Therefore, this module will be replaced with
--- some "Exceptions" module.
+-- going to move onto 'Control.Monad.Catch.MonadThrow'. Therefore, this module
+-- will be replaced with some "Exceptions" module.
 
 module Decaf.Client.Internal.Error where
 

--- a/src/Decaf/Client/Internal/Error.hs
+++ b/src/Decaf/Client/Internal/Error.hs
@@ -10,12 +10,14 @@ import Control.Monad.Except (MonadError(throwError))
 
 
 -- | Type definition for DECAF client errors.
-newtype DecafClientError = DecafClientError String deriving (Show)
+newtype DecafClientError = DecafClientError
+  { unDecafClientError :: String
+  } deriving (Show)
 
 
 -- | Throws a DECAF client error.
 --
 -- >>> throwDecafClientError "Invalid request" :: Either DecafClientError ()
--- Left (DecafClientError "Invalid request")
+-- Left (DecafClientError {unDecafClientError = "Invalid request"})
 throwDecafClientError :: MonadError DecafClientError m => String -> m a
 throwDecafClientError = throwError . DecafClientError

--- a/src/Decaf/Client/Internal/Exception.hs
+++ b/src/Decaf/Client/Internal/Exception.hs
@@ -1,0 +1,41 @@
+-- | This module provides definitions for exceptions "Decaf.Client" module can
+-- throw and related helpers.
+
+module Decaf.Client.Internal.Exception where
+
+import           Control.Exception   (Exception, IOException)
+import           Control.Monad.Catch (MonadThrow(throwM))
+import qualified Data.Text           as T
+import           GHC.Stack           (HasCallStack)
+
+
+-- | Type encoding of the exception that can be thrown by "Decaf.Client".
+data DecafClientException where
+  DecafClientIOException :: HasCallStack => T.Text -> IOException -> DecafClientException
+  DecafClientParseException :: HasCallStack => T.Text -> T.Text -> DecafClientException
+
+
+deriving instance Show DecafClientException
+
+
+instance Exception DecafClientException
+
+
+-- | Throws a 'DecafClientIOException' exception.
+throwIOException
+  :: HasCallStack
+  => MonadThrow m
+  => T.Text       -- ^ Message.
+  -> IOException  -- ^ Underlying IO exception.
+  -> m a
+throwIOException msg exc = throwM (DecafClientIOException msg exc)
+
+
+-- | Throws a 'DecafClientParseException' exception.
+throwParseException
+  :: HasCallStack
+  => MonadThrow m
+  => T.Text  -- ^ Message.
+  -> T.Text  -- ^ Parse error.
+  -> m a
+throwParseException msg err = throwM (DecafClientParseException msg err)

--- a/src/Decaf/Client/Internal/Profile.hs
+++ b/src/Decaf/Client/Internal/Profile.hs
@@ -1,0 +1,82 @@
+-- | This module provides definitions to work on profiles.
+
+{-# LANGUAGE DataKinds   #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Decaf.Client.Internal.Profile where
+
+import           Control.Exception                 (IOException, catch)
+import           Control.Monad.Catch               (MonadCatch, MonadThrow)
+import           Control.Monad.IO.Class            (MonadIO(liftIO))
+import qualified Data.ByteString                   as B
+import           Data.Foldable                     (find)
+import qualified Data.Text                         as T
+import qualified Data.Yaml                         as Yaml
+import           Decaf.Client.Internal.Credentials (Credentials)
+import           Decaf.Client.Internal.Exception   (throwIOException, throwParseException)
+import           Decaf.Client.Internal.Remote      (Remote)
+import qualified Deriving.Aeson.Stock              as DAS
+import           GHC.Stack                         (HasCallStack)
+
+
+-- | A DECAF Instance user profile for constructing a 'DecafClient'.
+--
+-- >>> import Decaf.Client.Internal.Credentials
+-- >>> import Decaf.Client.Internal.Remote
+--
+-- >>> Right remote = parseRemote "https://telostest.decafhub.com"
+-- >>> let credentials = CredentialsBasic (BasicCredentials "username" "password")
+--
+-- >>> let json = Data.Aeson.encode (Profile "test" remote credentials)
+-- >>> json
+-- "{\"name\":\"test\",\"url\":\"https://telostest.decafhub.com\",\"credentials\":{\"type\":\"basic\",\"value\":{\"username\":\"username\",\"password\":\"password\"}}}"
+-- >>> Data.Aeson.decode @Profile json
+-- Just (Profile {profileName = "test", profileUrl = [https]://[telostest.decafhub.com]:[443], profileCredentials = <********>})
+data Profile = Profile
+  { profileName        :: !T.Text
+  , profileUrl         :: !Remote
+  , profileCredentials :: !Credentials
+  }
+  deriving (Eq, DAS.Generic, Show)
+  deriving (DAS.FromJSON, DAS.ToJSON) via DAS.PrefixedSnake "profile" Profile
+
+
+-- | Attempts to read and return profiles from a file at the given filepath.
+readProfiles
+  :: HasCallStack
+  => MonadIO m
+  => MonadCatch m
+  => MonadThrow m
+  => FilePath
+  -> m [Profile]
+readProfiles fp = liftIO (B.readFile fp `catch` transformIOException) >>= parseProfiles
+  where
+    transformIOException :: MonadThrow m => IOException -> m a
+    transformIOException exc = throwIOException ("Cannot read profiles file: " <> T.pack fp) exc
+
+
+-- | Attempts to parse and return profiles from given JSON contents.
+parseProfiles
+  :: HasCallStack
+  => MonadIO m
+  => MonadThrow m
+  => B.ByteString
+  -> m [Profile]
+parseProfiles content = case Yaml.decodeEither' content of
+  Left err -> throwParseException "Error while parsing profiles" (T.pack . show $ err)
+  Right sp -> pure sp
+
+
+-- | Attempts to find and return the profile by the given name in the given
+-- profiles file.
+readProfile
+  :: HasCallStack
+  => MonadIO m
+  => MonadCatch m
+  => MonadThrow m
+  => T.Text
+  -> FilePath
+  -> m (Maybe Profile)
+readProfile name fp = do
+  profiles <- readProfiles fp
+  pure $ find ((==) name . profileName) profiles

--- a/src/Decaf/Client/Internal/Profile.hs
+++ b/src/Decaf/Client/Internal/Profile.hs
@@ -1,7 +1,8 @@
 -- | This module provides definitions to work on profiles.
 
-{-# LANGUAGE DataKinds   #-}
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE DerivingVia     #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Decaf.Client.Internal.Profile where
 
@@ -12,6 +13,7 @@ import qualified Data.ByteString                   as B
 import           Data.Foldable                     (find)
 import qualified Data.Text                         as T
 import qualified Data.Yaml                         as Yaml
+import           Decaf.Client.Internal.Client      (DecafClient, mkDecafClient)
 import           Decaf.Client.Internal.Credentials (Credentials)
 import           Decaf.Client.Internal.Exception   (throwIOException, throwParseException)
 import           Decaf.Client.Internal.Remote      (Remote)
@@ -29,12 +31,12 @@ import           GHC.Stack                         (HasCallStack)
 --
 -- >>> let json = Data.Aeson.encode (Profile "test" remote credentials)
 -- >>> json
--- "{\"name\":\"test\",\"url\":\"https://telostest.decafhub.com\",\"credentials\":{\"type\":\"basic\",\"value\":{\"username\":\"username\",\"password\":\"password\"}}}"
+-- "{\"name\":\"test\",\"remote\":\"https://telostest.decafhub.com\",\"credentials\":{\"type\":\"basic\",\"value\":{\"username\":\"username\",\"password\":\"password\"}}}"
 -- >>> Data.Aeson.decode @Profile json
--- Just (Profile {profileName = "test", profileUrl = [https]://[telostest.decafhub.com]:[443], profileCredentials = <********>})
+-- Just (Profile {profileName = "test", profileRemote = [https]://[telostest.decafhub.com]:[443], profileCredentials = <********>})
 data Profile = Profile
   { profileName        :: !T.Text
-  , profileUrl         :: !Remote
+  , profileRemote      :: !Remote
   , profileCredentials :: !Credentials
   }
   deriving (Eq, DAS.Generic, Show)
@@ -80,3 +82,10 @@ readProfile
 readProfile name fp = do
   profiles <- readProfiles fp
   pure $ find ((==) name . profileName) profiles
+
+
+-- | Builds a 'DecafClient' from the given 'Profile'.
+mkClientFromProfile
+  :: Profile
+  -> DecafClient
+mkClientFromProfile Profile{..} = mkDecafClient profileRemote profileCredentials

--- a/src/Decaf/Client/Internal/Remote.hs
+++ b/src/Decaf/Client/Internal/Remote.hs
@@ -6,7 +6,7 @@ import           Control.Monad.Except        (MonadError)
 import qualified Data.Char                   as C
 import           Data.Maybe                  (fromMaybe)
 import qualified Data.Text                   as T
-import           Decaf.Client.Internal.Error (DecafClientError, throwDecafClientError)
+import           Decaf.Client.Internal.Error (DecafClientError(unDecafClientError), throwDecafClientError)
 import           Decaf.Client.Internal.Utils (dropLeading, dropTrailing, nonEmptyString)
 import qualified Network.URI                 as U
 import           Text.Printf                 (printf)
@@ -85,7 +85,8 @@ remoteUrl (Remote h p s) = T.pack $ printf "%s://%s:%d" s' h' p'
 
 -- | Attempts to parse a given URL as a DECAF Instance 'Remote'.
 --
--- >>> import Decaf.Client
+-- >>> import Decaf.Client.Internal.Error
+-- >>> import Decaf.Client.Internal.Remote
 -- >>> parseRemote "http://localhost" :: Either DecafClientError Remote
 -- Right [http]://[localhost]:[80]
 -- >>> parseRemote "https://localhost" :: Either DecafClientError Remote
@@ -97,19 +98,19 @@ remoteUrl (Remote h p s) = T.pack $ printf "%s://%s:%d" s' h' p'
 -- >>> parseRemote "https://localhost:8443/path-segment-to-be-truncated" :: Either DecafClientError Remote
 -- Right [https]://[localhost]:[8443]
 -- >>> parseRemote "" :: Either DecafClientError Remote
--- Left (DecafClientError "Can not parse remote url: ''")
+-- Left (DecafClientError {unDecafClientError = "Can not parse remote url: ''"})
 -- >>> parseRemote "weird" :: Either DecafClientError Remote
--- Left (DecafClientError "Can not parse remote url: 'weird'")
+-- Left (DecafClientError {unDecafClientError = "Can not parse remote url: 'weird'"})
 -- >>> parseRemote "httpk://localhost:8443" :: Either DecafClientError Remote
--- Left (DecafClientError "Unknown protocol: httpk")
+-- Left (DecafClientError {unDecafClientError = "Unknown protocol: httpk"})
 -- >>> parseRemote "http:" :: Either DecafClientError Remote
--- Left (DecafClientError "Can not parse authority from URI: 'http:'")
+-- Left (DecafClientError {unDecafClientError = "Can not parse authority from URI: 'http:'"})
 -- >>> parseRemote "http:/" :: Either DecafClientError Remote
--- Left (DecafClientError "Can not parse authority from URI: 'http:/'")
+-- Left (DecafClientError {unDecafClientError = "Can not parse authority from URI: 'http:/'"})
 -- >>> parseRemote "http://" :: Either DecafClientError Remote
--- Left (DecafClientError "Empty host value")
+-- Left (DecafClientError {unDecafClientError = "Empty host value"})
 -- >>> parseRemote "http://a:" :: Either DecafClientError Remote
--- Left (DecafClientError "Can not parse port from URI: 'URIAuth {uriUserInfo = \"\", uriRegName = \"a\", uriPort = \":\"}'")
+-- Left (DecafClientError {unDecafClientError = "Can not parse port from URI: 'URIAuth {uriUserInfo = \"\", uriRegName = \"a\", uriPort = \":\"}'"})
 parseRemote :: MonadError DecafClientError m => T.Text -> m Remote
 parseRemote url = do
   uri <- parseUri' $ T.unpack url
@@ -120,11 +121,11 @@ parseRemote url = do
 
 -- | Parses the remote URI.
 --
--- >>> import Decaf.Client
+-- >>> import Decaf.Client.Internal.Error
 -- >>> parseUri' "" :: Either DecafClientError U.URI
--- Left (DecafClientError "Can not parse remote url: ''")
+-- Left (DecafClientError {unDecafClientError = "Can not parse remote url: ''"})
 -- >>> parseUri' "/" :: Either DecafClientError U.URI
--- Left (DecafClientError "Can not parse remote url: '/'")
+-- Left (DecafClientError {unDecafClientError = "Can not parse remote url: '/'"})
 -- >>> parseUri' "http://localhost" :: Either DecafClientError U.URI
 -- Right http://localhost
 -- >>> parseUri' "https://localhost:8443" :: Either DecafClientError U.URI
@@ -169,7 +170,7 @@ parsePort' uri = maybe err pure . sequence$ (readMaybe . dropLeading ':' <$> (no
 
 -- | Predicate to define if the URI indicates secure HTTP or not.
 --
--- >>> import Decaf.Client
+-- >>> import Decaf.Client.Internal.Error
 -- >>> isSecureHttp' "http" :: Either DecafClientError Bool
 -- Right False
 -- >>> isSecureHttp' "https" :: Either DecafClientError Bool
@@ -177,9 +178,9 @@ parsePort' uri = maybe err pure . sequence$ (readMaybe . dropLeading ':' <$> (no
 -- >>> fmap isSecureHttp' ["http", "https", "Http", "HTTP", "Https", "Https", "Http:", "Https:"] :: [Either DecafClientError Bool]
 -- [Right False,Right True,Right False,Right False,Right True,Right True,Right False,Right True]
 -- >>> fmap isSecureHttp' ["htt", "htts", "Htp", "HTP", "Htps", "Htps"] :: [Either DecafClientError Bool]
--- [Left (DecafClientError "Unknown protocol: htt"),Left (DecafClientError "Unknown protocol: htts"),Left (DecafClientError "Unknown protocol: htp"),Left (DecafClientError "Unknown protocol: htp"),Left (DecafClientError "Unknown protocol: htps"),Left (DecafClientError "Unknown protocol: htps")]
+-- [Left (DecafClientError {unDecafClientError = "Unknown protocol: htt"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htts"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htp"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htp"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htps"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htps"})]
 -- >>> fmap isSecureHttp' ["htt", "htts"] :: [Either DecafClientError Bool]
--- [Left (DecafClientError "Unknown protocol: htt"),Left (DecafClientError "Unknown protocol: htts")]
+-- [Left (DecafClientError {unDecafClientError = "Unknown protocol: htt"}),Left (DecafClientError {unDecafClientError = "Unknown protocol: htts"})]
 isSecureHttp' :: MonadError DecafClientError m => String -> m Bool
 isSecureHttp' = isSecure' . fmap C.toLower . dropTrailing ':'
   where

--- a/src/Decaf/Client/Internal/Remote.hs
+++ b/src/Decaf/Client/Internal/Remote.hs
@@ -3,6 +3,7 @@
 module Decaf.Client.Internal.Remote where
 
 import           Control.Monad.Except        (MonadError)
+import qualified Data.Aeson                  as Aeson
 import qualified Data.Char                   as C
 import           Data.Maybe                  (fromMaybe)
 import qualified Data.Text                   as T
@@ -28,6 +29,7 @@ data Remote = Remote
   , remotePort   :: !(Maybe Int)
   , remoteSecure :: !Bool
   }
+  deriving Eq
 
 
 instance Show Remote where
@@ -36,6 +38,16 @@ instance Show Remote where
       s' = (if s then "https" else "http") :: String
       h' = T.unpack h
       p' = fromMaybe (if s then 443 else 80) p
+
+
+instance Aeson.FromJSON Remote where
+  parseJSON = Aeson.withText "Remote" $ \x -> case parseRemote x of
+    Left err -> fail (unDecafClientError err)
+    Right sr -> pure sr
+
+
+instance Aeson.ToJSON Remote where
+  toJSON = Aeson.String . remoteToUrl
 
 
 -- | Converts the 'Remote' to a sanitized url.


### PR DESCRIPTION
- refactor: add value accessor to DecafClientError newtype
- feat: add Aeson.{FromJSON,ToJSON} instances to Remote data type
- refactor: fix Aeson.{FromJSON,ToJSON} instances of Credentials data type
- refactor: add DecafClientException data definition and helpers
- feat: add Profile data definition and helpers
- refactor: put DecafClient and constructor in its own internal module
- refactor: rename monadic DecafClient constructor, add pure one
- chore: improve Profile module definitions
- chore: remove example application from build configuration
- refactor(main): refactor decafcli application for batch Microlot query runner
- chore(build): do not use -Werror, use -Wunused-packages, revisit deps
- chore(docs): fix Haddock warnings
